### PR TITLE
Bypassing object mutation

### DIFF
--- a/src/lib/logger.d.ts
+++ b/src/lib/logger.d.ts
@@ -1,5 +1,11 @@
 declare module '@zenvia/logger' {
-  import { Logger } from 'winston';
-  const logger: Logger;
+  import { Logger, LeveledLogMethod } from 'winston';
+
+  interface ZenviaLogger extends Logger {
+    fatal: LeveledLogMethod;
+    isFatalEnabled(): boolean;
+  }
+
+  const logger: ZenviaLogger;
   export = logger;
 }

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -83,7 +83,7 @@ function logFn(level, msg, ...splat) {
       };
     }
   }
-  return logger.log(level, msg, ...splat);
+  return logger.realLog(level, msg, ...splat);
 }
 
 function isLevelEnabledFn(level) {
@@ -92,15 +92,15 @@ function isLevelEnabledFn(level) {
   };
 }
 
-module.exports = {
-  ...logger,
-  log: logFn,
-  fatal: leveledLogFn('fatal'),
-  error: leveledLogFn('error'),
-  warn: leveledLogFn('warn'),
-  info: leveledLogFn('info'),
-  debug: leveledLogFn('debug'),
-  verbose: leveledLogFn('verbose'),
-  silly: leveledLogFn('silly'),
-  isFatalEnabled: isLevelEnabledFn('fatal'),
-};
+logger.fatal = leveledLogFn('fatal');
+logger.error = leveledLogFn('error');
+logger.warn = leveledLogFn('warn');
+logger.info = leveledLogFn('info');
+logger.debug = leveledLogFn('debug');
+logger.verbose = leveledLogFn('verbose');
+logger.silly = leveledLogFn('silly');
+logger.isFatalEnabled = isLevelEnabledFn('fatal');
+logger.realLog = logger.log;
+logger.log = logFn;
+
+module.exports = logger;

--- a/test/lib/logger.spec.js
+++ b/test/lib/logger.spec.js
@@ -45,19 +45,14 @@ describe('Logger test', () => {
       JSON.parse(actualOutput).should.be.deep.equal(expectedOutput);
     });
 
-    it('should log empty message fields when message is not provided', () => {
+    it('should log nothing when message is not provided', () => {
       logger.info();
-      const expectedOutput = {
-        '@timestamp': '2018-06-05T18:20:42.345Z',
-        '@version': 1,
-        application: 'application-name',
-        host: os.hostname(),
-        message: '',
-        level: 'INFO',
-      };
+      stdMocks.flush().stdout.length.should.be.equal(0);
+    });
 
-      const actualOutput = stdMocks.flush().stdout[0];
-      JSON.parse(actualOutput).should.be.deep.equal(expectedOutput);
+    it('should log nothing when only level provided', () => {
+      logger.log('info');
+      stdMocks.flush().stdout.length.should.be.equal(0);
     });
 
     it('should log @timestamp, application, message and level fields', () => {
@@ -176,6 +171,7 @@ describe('Logger test', () => {
 
   describe('Logging level', () => {
     it('should log as FATAL level', () => {
+      logger.isFatalEnabled().should.be.equal(true);
       logger.fatal('some message');
       const actualOutput = JSON.parse(stdMocks.flush().stderr[0]);
       actualOutput.should.have.property('level').and.be.equal('FATAL');
@@ -249,6 +245,36 @@ describe('Logger test', () => {
 
       const actualOutput = stdMocks.flush().stdout[0];
       actualOutput.should.be.equal('2018-06-05T18:20:42.345Z - debug: some message\n');
+    });
+  });
+
+  describe('Reliability', () => {
+    it('should not mutate the original error object when log this object without any other data', () => {
+      const error = new Error('some reason');
+      error.should.not.have.property('level');
+      logger.info(error);
+      error.should.not.have.property('level');
+    });
+
+    it('should not mutate the original object when log this object without any other data', () => {
+      const obj = { message: 'some value' };
+      obj.should.not.have.property('level');
+      logger.info(obj);
+      obj.should.not.have.property('level');
+    });
+
+    it('should not mutate the original error object when log with level and object', () => {
+      const error = new Error('some reason');
+      error.should.not.have.property('level');
+      logger.log('error', error);
+      error.should.not.have.property('level');
+    });
+
+    it('should not mutate the original object when log with level and object', () => {
+      const obj = { property: 'some value' };
+      obj.should.not.have.property('level');
+      logger.log('info', obj);
+      obj.should.not.have.property('level');
     });
   });
 });

--- a/test/lib/logger.spec.js
+++ b/test/lib/logger.spec.js
@@ -45,12 +45,12 @@ describe('Logger test', () => {
       JSON.parse(actualOutput).should.be.deep.equal(expectedOutput);
     });
 
-    it('should log nothing when message is not provided', () => {
+    it('should not log when message is not provided', () => {
       logger.info();
       stdMocks.flush().stdout.length.should.be.equal(0);
     });
 
-    it('should log nothing when only level provided', () => {
+    it('should not log when only level provided', () => {
       logger.log('info');
       stdMocks.flush().stdout.length.should.be.equal(0);
     });


### PR DESCRIPTION
Hi guys!

Since version 3 of winston lib logger, in some scenario, the object passed to be logged will be mutate inside winston. According to them, it is a deliberated behavior in favor of performance improvement. 

However, this kind of behavior can lead to errors, since sometimes we log the object before send it into an API response so, the response data can contain non-desired field. 

To solve this, we are overriding some log methods to replace the original object for an cloned object, protecting in this way the integrity of the data.