### PR TITLE
Correção de CRLF attack na lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenvia/logger",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A wrapper for Winston Logging Node.js library that formats the output on STDOUT as Logstash JSON format.",
   "license": "MIT",
   "main": "./src/index",

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -10,7 +10,25 @@ const rTrace = require('cls-rtracer');
 
 const appPackage = require(path.join(appRootDir, 'package'));
 
+const sanitizeInfo = (info) => {
+  const sanitizeCRLFInjection = (str) => str
+    .replace(/\n|\r/g, (x) => (x === '\n' ? '#n' : '#r'));
+
+  Object.keys(info).forEach((key) => {
+    if (typeof info[key] === 'string') {
+      info[key] = sanitizeCRLFInjection(info[key]);
+      return;
+    }
+
+    if (info[key] instanceof Function) {
+      delete info[key];
+    }
+  });
+};
+
 const customFormatJson = winston.format((info) => {
+  sanitizeInfo(info);
+
   let stack;
 
   if (info.stack) {
@@ -30,12 +48,6 @@ const customFormatJson = winston.format((info) => {
     stack_trace: stack,
     traceId: rTrace.id(),
   };
-
-  Object.keys(info).forEach((key) => {
-    if (info[key] instanceof Function) {
-      delete info[key];
-    }
-  });
 
   return info;
 });

--- a/test/lib/logger.spec.js
+++ b/test/lib/logger.spec.js
@@ -241,6 +241,50 @@ describe('Logger test', () => {
   });
 
   describe('Logging format', () => {
+    it('should replace LF characters from log (POSIX systems)', () => {
+      logger.debug(`some message
+other CRLF injection message`);
+      const expectedOutput = {
+        '@timestamp': '2018-06-05T18:20:42.345Z',
+        '@version': 1,
+        application: 'application-name',
+        host: os.hostname(),
+        message: 'some message#nother CRLF injection message',
+        level: 'DEBUG',
+      };
+
+      const actualOutput = stdMocks.flush().stdout[0];
+      JSON.parse(actualOutput).should.be.deep.equal(expectedOutput);
+
+      logger.debug('some\n CRLF\n injection\n message');
+      const expectedOutput2 = {
+        '@timestamp': '2018-06-05T18:20:42.345Z',
+        '@version': 1,
+        application: 'application-name',
+        host: os.hostname(),
+        message: 'some#n CRLF#n injection#n message',
+        level: 'DEBUG',
+      };
+
+      const actualOutput2 = stdMocks.flush().stdout[0];
+      JSON.parse(actualOutput2).should.be.deep.equal(expectedOutput2);
+    });
+
+    it('should replace CRLF characters from log (Windows systems)', () => {
+      logger.debug('some\r\n CRLF\r\n injection\r\n message');
+      const expectedOutput = {
+        '@timestamp': '2018-06-05T18:20:42.345Z',
+        '@version': 1,
+        application: 'application-name',
+        host: os.hostname(),
+        message: 'some#r#n CRLF#r#n injection#r#n message',
+        level: 'DEBUG',
+      };
+
+      const actualOutput = stdMocks.flush().stdout[0];
+      JSON.parse(actualOutput).should.be.deep.equal(expectedOutput);
+    });
+
     it('should get not format when LOGGING_FORMATTER_DISABLED environment is true', () => {
       delete require.cache[require.resolve('../../src/lib/logger')];
       process.env.LOGGING_FORMATTER_DISABLED = 'true';


### PR DESCRIPTION
# O que é
Basicamente na nossa ferramenta de análise estática de código (Veracode) em diversos projetos foi identificado uma vulnerabilidade para aceitar ataques do tipo CLRF Attack, onde um usuário malicioso pode forjar entradas de log ou injetar conteúdo malicioso em logs.

# O que foi feito
Já que todos os projetos node.js que apontaram erros desse tipo utilizam a lib genérica de logs, nada mais fácil do que tratar o problema na raiz, por isso foi adicionado uma função a mais para sanitizar logs. Inclusive num futuro possa ser que esse método receba novas formas sanitizar dados de logs.

Segreguei em uma função chamada `sanitizeInfo` a lógica que já existia de remover atributos do tipo `Function` da lib, assim como ela também é responsável por chamar uma nova função criada chamada de `sanitizeCRLFInjection` para atributos do tipo string. Com isso futuras sanitizações de dados que possam vir a surgir ficariam isoladas nessa função. E na função `customFormatJson`, alterei para que o primeira coisa a se fazer, é sanitizar a `info`, e não depois. Pois todos os campos que usamos para enriquecer o log em seguida, são de nosso controle, logo não tem perigo de `CRLF Injection`, e consequentemente não precisariamos ter o trabalho de iterar sobre eles, para tentar sanitizar.