### PR TITLE
revert: revert fix CLRF attack (#22)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run lint
       run: npm run lint
     - name: Run test
-      run: npm run test:coveralls
+      run: npm test
     - name: Coveralls
       uses: coverallsapp/github-action@v2
       with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run lint
       run: npm run lint
     - name: Run test
-      run: npm test
+      run: npm run test:coveralls
     - name: Coveralls
       uses: coverallsapp/github-action@v2
       with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zenvia/logger",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zenvia/logger",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "app-root-dir": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zenvia/logger",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A wrapper for Winston Logging Node.js library that formats the output on STDOUT as Logstash JSON format.",
   "license": "MIT",
   "main": "./src/index",

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -10,25 +10,7 @@ const rTrace = require('cls-rtracer');
 
 const appPackage = require(path.join(appRootDir, 'package'));
 
-const sanitizeInfo = (info) => {
-  const sanitizeCRLFInjection = (str) => str
-    .replace(/\n|\r/g, (x) => (x === '\n' ? '#n' : '#r'));
-
-  Object.keys(info).forEach((key) => {
-    if (typeof info[key] === 'string') {
-      info[key] = sanitizeCRLFInjection(info[key]);
-      return;
-    }
-
-    if (info[key] instanceof Function) {
-      delete info[key];
-    }
-  });
-};
-
 const customFormatJson = winston.format((info) => {
-  sanitizeInfo(info);
-
   let stack;
 
   if (info.stack) {
@@ -48,6 +30,12 @@ const customFormatJson = winston.format((info) => {
     stack_trace: stack,
     traceId: rTrace.id(),
   };
+
+  Object.keys(info).forEach((key) => {
+    if (info[key] instanceof Function) {
+      delete info[key];
+    }
+  });
 
   return info;
 });

--- a/test/lib/logger.spec.js
+++ b/test/lib/logger.spec.js
@@ -241,50 +241,6 @@ describe('Logger test', () => {
   });
 
   describe('Logging format', () => {
-    it('should replace LF characters from log (POSIX systems)', () => {
-      logger.debug(`some message
-other CRLF injection message`);
-      const expectedOutput = {
-        '@timestamp': '2018-06-05T18:20:42.345Z',
-        '@version': 1,
-        application: 'application-name',
-        host: os.hostname(),
-        message: 'some message#nother CRLF injection message',
-        level: 'DEBUG',
-      };
-
-      const actualOutput = stdMocks.flush().stdout[0];
-      JSON.parse(actualOutput).should.be.deep.equal(expectedOutput);
-
-      logger.debug('some\n CRLF\n injection\n message');
-      const expectedOutput2 = {
-        '@timestamp': '2018-06-05T18:20:42.345Z',
-        '@version': 1,
-        application: 'application-name',
-        host: os.hostname(),
-        message: 'some#n CRLF#n injection#n message',
-        level: 'DEBUG',
-      };
-
-      const actualOutput2 = stdMocks.flush().stdout[0];
-      JSON.parse(actualOutput2).should.be.deep.equal(expectedOutput2);
-    });
-
-    it('should replace CRLF characters from log (Windows systems)', () => {
-      logger.debug('some\r\n CRLF\r\n injection\r\n message');
-      const expectedOutput = {
-        '@timestamp': '2018-06-05T18:20:42.345Z',
-        '@version': 1,
-        application: 'application-name',
-        host: os.hostname(),
-        message: 'some#r#n CRLF#r#n injection#r#n message',
-        level: 'DEBUG',
-      };
-
-      const actualOutput = stdMocks.flush().stdout[0];
-      JSON.parse(actualOutput).should.be.deep.equal(expectedOutput);
-    });
-
     it('should get not format when LOGGING_FORMATTER_DISABLED environment is true', () => {
       delete require.cache[require.resolve('../../src/lib/logger')];
       process.env.LOGGING_FORMATTER_DISABLED = 'true';

--- a/test/lib/logger.spec.js
+++ b/test/lib/logger.spec.js
@@ -70,6 +70,21 @@ describe('Logger test', () => {
       JSON.parse(actualOutput).should.be.deep.equal(expectedOutput);
     });
 
+    it('should remove attributes that are log functions, leaving only the @timestamp, application, message and level fields', () => {
+      logger.info('some message', { field1: () => {} });
+      const expectedOutput = {
+        '@timestamp': '2018-06-05T18:20:42.345Z',
+        '@version': 1,
+        application: 'application-name',
+        host: os.hostname(),
+        message: 'some message',
+        level: 'INFO',
+      };
+
+      const actualOutput = stdMocks.flush().stdout[0];
+      JSON.parse(actualOutput).should.be.deep.equal(expectedOutput);
+    });
+
     it('should log @timestamp, application, message, level and environment fields', () => {
       process.env.NODE_ENV = 'test';
       logger.info('some message');


### PR DESCRIPTION
## O que é?

Na última auditoria fizemos em plataforma várias correções de vulnerabilidades encontradas pelo veracode, sendo uma nesse repo, através do PR (#22), visando corrigir vulnerabilidades CRLF Attack. Porém como bem mencionado pelo Rafael no [comentário](https://github.com/zenvia/zenvia-logger-node/pull/22#issuecomment-1243935125) (pouco depois do merge), não faz sentido tentar corrigir esse tipo de attack, já que a própria lib, gera logs no formato JSON, logo possíveis variáveis a serem injetadas com quebras de linhas por um atacante malicioso, serão interpretadas como string normais de JSON, em futuras depurações de logs.

Logo trocar `\n` por `#n` e `\r` por `#r`, não terá benefício nenhum, inclusive porderá gerar confusão em logs de verdade, por exemplo quando loggar o `stackTrace` de error, segue exemplo abaixo:

![image](https://github.com/zenvia/zenvia-logger-node/assets/38543363/2f881bec-6b3d-4f1e-904c-9f17206509f2)

## O que foi feito?

Basicamente, revertido o comportamento adicionado no PR (#22).